### PR TITLE
DM-30860: Adhere to doc template

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,1 @@
+Copyright 2020-2021 The Trustees of Princeton University

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -1,3 +1,0 @@
-# -*- python -*-
-from lsst.sconsUtils import scripts
-scripts.BasicSConscript.doc()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,14 @@
+"""Sphinx configuration file for an LSST stack package.
+
+This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
+"""
+
+from documenteer.conf.pipelinespkg import *
+
+
+project = "meas_extensions_gaap"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,12 @@
+###############################################
+meas_extensions_gaap documentation preview
+###############################################
+
+.. This page is for local development only. It isn't published to pipelines.lsst.io.
+
+.. Link the index pages of package and module documentation directions (listed in manifest.yaml).
+
+.. toctree::
+   :maxdepth: 1
+
+   lsst.meas.extensions.gaap/index

--- a/doc/lsst.meas.extensions.gaap/index.rst
+++ b/doc/lsst.meas.extensions.gaap/index.rst
@@ -1,0 +1,90 @@
+.. py:currentmodule:: lsst.meas.extensions.gaap
+
+.. _lsst.meas.extensions.gaap:
+
+#########################
+lsst.meas.extensions.gaap
+#########################
+
+.. Paragraph that describes what this Python module does and links to related modules and frameworks.
+
+.. .. _lsst.meas.extensions.gaap-using:
+
+.. Using lsst.meas.extensions.gaap
+.. ===============================
+
+.. toctree linking to topics related to using the module's APIs.
+
+.. .. toctree::
+..    :maxdepth: 1
+
+.. _lsst.meas.extensions.gaap-contributing:
+
+Contributing
+============
+
+``lsst.meas.extensions.gaap`` is developed at https://github.com/lsst/meas_extensions_gaap.
+You can find Jira issues for this module under the `meas_extensions_gaap <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20meas_extensions_gaap>`_ component.
+
+.. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
+
+.. .. toctree::
+..    :maxdepth: 1
+
+.. _lsst.meas.extensions.gaap-command-line-taskref:
+
+Task reference
+==============
+
+.. _lsst.meas.extensions.gaap-pipeline-tasks:
+
+Pipeline tasks
+--------------
+
+.. lsst-pipelinetasks::
+   :root: lsst.meas.extensions.gaap
+
+.. _lsst.meas.extensions.gaap-command-line-tasks:
+
+Command-line tasks
+------------------
+
+.. lsst-cmdlinetasks::
+   :root: lsst.meas.extensions.gaap
+
+.. _lsst.meas.extensions.gaap-tasks:
+
+Tasks
+-----
+
+.. lsst-tasks::
+   :root: lsst.meas.extensions.gaap
+   :toctree: tasks
+
+.. _lsst.meas.extensions.gaap-configs:
+
+Configurations
+--------------
+
+.. lsst-configs::
+   :root: lsst.meas.extensions.gaap
+   :toctree: configs
+
+.. .. _lsst.meas.extensions.gaap-scripts:
+
+.. Script reference
+.. ================
+
+.. .. TODO: Add an item to this toctree for each script reference topic in the scripts subdirectory.
+
+.. .. toctree::
+..    :maxdepth: 1
+
+.. .. _lsst.meas.extensions.gaap-pyapi:
+
+Python API reference
+====================
+
+.. automodapi:: lsst.meas.extensions.gaap
+   :no-main-docstr:
+   :no-inheritance-diagram:

--- a/doc/manifest.yaml
+++ b/doc/manifest.yaml
@@ -1,0 +1,12 @@
+# Documentation manifest.
+
+# List of names of Python modules in this package.
+# For each module there is a corresponding module doc subdirectory.
+modules:
+  - "lsst.meas.extensions.gaap"
+
+# Name of the static content directories (subdirectories of `_static`).
+# Static content directories are usually named after the package.
+# Most packages do not need a static content directory (leave commented out).
+# statics:
+#   - "_static/meas_extensions_gaap"

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503
 exclude =
     bin,
-    doc,
+    doc/conf.py,
     **/*/__init__.py,
     **/*/version.py,
     tests/.tests


### PR DESCRIPTION
The files in the doc/ folder were out of date and were breaking the build on Jenkins. The structure in this PR adheres to the guidance provided for python-only package in lsst/templates.