### PR TITLE
DM-31062: Use the plugin name by default

### DIFF
--- a/python/lsst/meas/extensions/gaap/_gaap.py
+++ b/python/lsst/meas/extensions/gaap/_gaap.py
@@ -219,7 +219,7 @@ class BaseGaapFluxConfig(measBase.BaseMeasurementPluginConfig):
             return suffix
         return "_".join((name, suffix))
 
-    def getAllGaapResultNames(self, name: Optional[str] = None) -> Generator[str]:
+    def getAllGaapResultNames(self, name: Optional[str] = PLUGIN_NAME) -> Generator[str]:
         """Generate the base names for all of the GAaP fields.
 
         For example, if the plugin is configured with `scalingFactors` = [1.15]

--- a/tests/test_gaap.py
+++ b/tests/test_gaap.py
@@ -640,7 +640,7 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
             catalog.append(record)
 
         catalog = catalog.copy(deep=True)
-        for baseName in gaapConfig.getAllGaapResultNames(name="ext_gaap_GaapFlux"):
+        for baseName in gaapConfig.getAllGaapResultNames():
             instFluxKey = schema.join(baseName, "instFlux")
             instFluxErrKey = schema.join(baseName, "instFluxErr")
             instFluxMean = catalog[instFluxKey].mean()


### PR DESCRIPTION
When generating the list of GAaP fields, use the plugin name as the
prefix by default instead of generating only the middle strings.