### PR TITLE
DM-31345: Fix the underlying bug resulting in PSF-matching failures in ci_hsc and ci_imsim

### DIFF
--- a/python/lsst/meas/extensions/gaap/_gaap.py
+++ b/python/lsst/meas/extensions/gaap/_gaap.py
@@ -555,7 +555,7 @@ class BaseGaapFluxMixin:
             raise measBase.FatalAlgorithmError("No PSF in exposure")
         wcs = exposure.getWcs()
 
-        seeing = psf.computeShape(center).getTraceRadius()
+        seeing = psf.computeShape(center).getDeterminantRadius()
         errorCollection = dict()
         for scalingFactor in self.config.scalingFactors:
             targetSigma = scalingFactor*seeing

--- a/python/lsst/meas/extensions/gaap/_gaap.py
+++ b/python/lsst/meas/extensions/gaap/_gaap.py
@@ -555,10 +555,10 @@ class BaseGaapFluxMixin:
             raise measBase.FatalAlgorithmError("No PSF in exposure")
         wcs = exposure.getWcs()
 
-        seeing = psf.computeShape(center).getDeterminantRadius()
+        psfSigma = psf.computeShape(center).getDeterminantRadius()
         errorCollection = dict()
         for scalingFactor in self.config.scalingFactors:
-            targetSigma = scalingFactor*seeing
+            targetSigma = scalingFactor*psfSigma
             # If this target PSF is bound to fail for all apertures,
             # set the flags and move on without PSF Gaussianization.
             if self._isAllFailure(measRecord, scalingFactor, targetSigma):

--- a/python/lsst/meas/extensions/gaap/_gaussianizePsf.py
+++ b/python/lsst/meas/extensions/gaap/_gaussianizePsf.py
@@ -120,6 +120,7 @@ class GaussianizePsfTask(ModelPsfMatchTask):
         targetPsfModel = result.targetPsfModel
         fwhmScience = exposure.getPsf().computeShape(center).getDeterminantRadius()*sigma2fwhm
         fwhmModel = targetPsfModel.computeShape().getDeterminantRadius()*sigma2fwhm
+        self.log.debug("Ratio of GAaP model to science PSF = %f", fwhmModel/fwhmScience)
 
         basisList = makeKernelBasisList(self.kConfig, fwhmScience, fwhmModel,
                                         basisSigmaGauss=basisSigmaGauss,

--- a/python/lsst/meas/extensions/gaap/_gaussianizePsf.py
+++ b/python/lsst/meas/extensions/gaap/_gaussianizePsf.py
@@ -118,7 +118,7 @@ class GaussianizePsfTask(ModelPsfMatchTask):
         result = self._buildCellSet(exposure, center, targetPsfModel)
         kernelCellSet = result.kernelCellSet
         targetPsfModel = result.targetPsfModel
-        fwhmScience = exposure.getPsf().computeShape().getDeterminantRadius()*sigma2fwhm
+        fwhmScience = exposure.getPsf().computeShape(center).getDeterminantRadius()*sigma2fwhm
         fwhmModel = targetPsfModel.computeShape().getDeterminantRadius()*sigma2fwhm
 
         basisList = makeKernelBasisList(self.kConfig, fwhmScience, fwhmModel,


### PR DESCRIPTION
The PSF shape needs to be computed at the centroid of the source of interest. There was a subtler issue with the scaling being done on trace radius in some places and on determinant radius in some other places, although this inconsistency had little role to play. Both of these are fixed in this ticket, and the messages about unable to find PSF-matching kernel do not appear any more.