### PR TITLE
DM-33446: Use TraceRadius in GAaP plugin

### DIFF
--- a/python/lsst/meas/extensions/gaap/_gaap.py
+++ b/python/lsst/meas/extensions/gaap/_gaap.py
@@ -552,7 +552,13 @@ class BaseGaapFluxMixin:
         wcs = exposure.getWcs()
 
         psfSigma = psf.computeShape(center).getTraceRadius()
-        errorCollection = dict()
+        if not (psfSigma > 0):  # This captures NaN and negative values.
+            errorCollection = {str(scalingFactor): measBase.MeasurementError("PSF size could not be measured")
+                               for scalingFactor in self.config.scalingFactor}
+            raise GaapConvolutionError(errorCollection)
+        else:
+            errorCollection = dict()
+
         for scalingFactor in self.config.scalingFactors:
             targetSigma = scalingFactor*psfSigma
             # If this target PSF is bound to fail for all apertures,

--- a/python/lsst/meas/extensions/gaap/_gaap.py
+++ b/python/lsst/meas/extensions/gaap/_gaap.py
@@ -551,7 +551,7 @@ class BaseGaapFluxMixin:
             raise measBase.FatalAlgorithmError("No PSF in exposure")
         wcs = exposure.getWcs()
 
-        psfSigma = psf.computeShape(center).getDeterminantRadius()
+        psfSigma = psf.computeShape(center).getTraceRadius()
         errorCollection = dict()
         for scalingFactor in self.config.scalingFactors:
             targetSigma = scalingFactor*psfSigma

--- a/python/lsst/meas/extensions/gaap/_gaussianizePsf.py
+++ b/python/lsst/meas/extensions/gaap/_gaussianizePsf.py
@@ -118,7 +118,7 @@ class GaussianizePsfTask(ModelPsfMatchTask):
         result = self._buildCellSet(exposure, center, targetPsfModel)
         kernelCellSet = result.kernelCellSet
         targetPsfModel = result.targetPsfModel
-        fwhmScience = exposure.getPsf().computeShape(center).getDeterminantRadius()*sigma2fwhm
+        fwhmScience = exposure.getPsf().computeShape(center).getTraceRadius()*sigma2fwhm
         fwhmModel = targetPsfModel.getSigma()*sigma2fwhm  # This works only because it is a `GaussianPsf`.
         self.log.debug("Ratio of GAaP model to science PSF = %f", fwhmModel/fwhmScience)
 


### PR DESCRIPTION
Replace `getDeterminantRadius` calls with `getTraceRadius`