### PR TITLE
DM-36000: Remove mention of command-line task

### DIFF
--- a/doc/lsst.meas.extensions.gaap/index.rst
+++ b/doc/lsst.meas.extensions.gaap/index.rst
@@ -44,14 +44,6 @@ Pipeline tasks
 .. lsst-pipelinetasks::
    :root: lsst.meas.extensions.gaap
 
-.. _lsst.meas.extensions.gaap-command-line-tasks:
-
-Command-line tasks
-------------------
-
-.. lsst-cmdlinetasks::
-   :root: lsst.meas.extensions.gaap
-
 .. _lsst.meas.extensions.gaap-tasks:
 
 Tasks


### PR DESCRIPTION
There aren't any tasks or pipeline tasks in this package so might want to remove all the code referring to those as well.