### PR TITLE
DM-49253-v29: Avoid setting the deprecated alardDegGaussDeconv field

### DIFF
--- a/python/lsst/meas/extensions/gaap/_gaap.py
+++ b/python/lsst/meas/extensions/gaap/_gaap.py
@@ -154,6 +154,7 @@ class BaseGaapFluxConfig(measBase.BaseMeasurementPluginConfig):
 
     def setDefaults(self) -> None:
         # Docstring inherited
+        super().setDefaults()
         self._modelPsfMatch.kernel.active.alardNGauss = 1
         self._modelPsfMatch.kernel.active.alardDegGauss = [4]
         self._modelPsfMatch.kernel.active.alardGaussBeta = 1.0

--- a/python/lsst/meas/extensions/gaap/_gaap.py
+++ b/python/lsst/meas/extensions/gaap/_gaap.py
@@ -155,7 +155,6 @@ class BaseGaapFluxConfig(measBase.BaseMeasurementPluginConfig):
     def setDefaults(self) -> None:
         # Docstring inherited
         self._modelPsfMatch.kernel.active.alardNGauss = 1
-        self._modelPsfMatch.kernel.active.alardDegGaussDeconv = 1
         self._modelPsfMatch.kernel.active.alardDegGauss = [4]
         self._modelPsfMatch.kernel.active.alardGaussBeta = 1.0
         self._modelPsfMatch.kernel.active.spatialKernelOrder = 0


### PR DESCRIPTION
Backporting the changes to v29